### PR TITLE
Treat lint warnings as errors

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -10,10 +10,11 @@ ci () {
   cargo upgrade --verbose
   cargo audit
 
-  cargo +nightly check && cargo +nightly fix --allow-dirty && cargo +nightly clippy --fix --allow-dirty && cargo +nightly fmt --all && cargo +nightly test
-  #cargo +nightly fmt --all
-  #cargo +nightly clippy --all-targets --all-features -- -Dwarnings
-  #cargo test
+  cargo +nightly check
+  cargo +nightly fix --allow-dirty
+  cargo +nightly clippy --all-targets --all-features -- -D warnings
+  cargo +nightly fmt --all
+  cargo +nightly test
 
   cargo +nightly udeps --all-targets
   # cargo udeps --all-targets

--- a/cli-justify/src/pdf_hybrid/mod.rs
+++ b/cli-justify/src/pdf_hybrid/mod.rs
@@ -21,12 +21,8 @@ mod tests {
 
   #[test]
   fn preserves_indent_when_trimmed_content_fits_line_width_exactly() {
-    let line = format!(
-      "   {}{}{}",
-      "Foo Bar".to_string(),
-      " ".repeat(31),
-      "Baz Qux Quux Corge"
-    );
+    let line =
+      format!("   {}{}{}", "Foo Bar", " ".repeat(31), "Baz Qux Quux Corge");
     let out = justify_pdf_hybrid(&line, 80);
     assert!(
       out[0].starts_with("   "),

--- a/cli-justify/src/pdf_hybrid/structure/lists.rs
+++ b/cli-justify/src/pdf_hybrid/structure/lists.rs
@@ -68,15 +68,11 @@ pub(crate) fn parse_list_marker(
 
   let remainder = &trimmed[idx..];
   let mut chars = remainder.chars();
-  let Some(delimiter) = chars.next() else {
-    return None;
-  };
+  let delimiter = chars.next()?;
   if delimiter != '.' && delimiter != ')' {
     return None;
   }
-  let Some(space) = chars.next() else {
-    return None;
-  };
+  let space = chars.next()?;
   if space != ' ' {
     return None;
   }

--- a/cli-justify/src/pdf_hybrid/structure/toc.rs
+++ b/cli-justify/src/pdf_hybrid/structure/toc.rs
@@ -132,7 +132,7 @@ pub(crate) fn parse_aligned_toc_row_start(
     return None;
   }
 
-  // TitleNumberLabel prefixes (`Plate N`, `Diagram N`, …) are ambiguous
+  // TitleNumber prefixes (`Plate N`, `Diagram N`, …) are ambiguous
   // without a clean trailing page number: a real TOC entry has the number
   // alone at the right margin (`Plate 14 … 313`), but a list-of-plates
   // section has them embedded inline ("page 313") with parens or quotes
@@ -142,7 +142,7 @@ pub(crate) fn parse_aligned_toc_row_start(
   if page_number.is_none()
     && matches!(
       classify_toc_entry_prefix(&entry_prefix),
-      Some(TocPrefixKind::TitleNumberLabel)
+      Some(TocPrefixKind::TitleNumber)
     )
   {
     return None;
@@ -182,9 +182,7 @@ pub(crate) fn parse_plain_aligned_toc_row(line: &str) -> Option<AlignedTocRow> {
 
   let (title, page_number) =
     split_trailing_numeric_token_with_min_gap(trimmed, 2);
-  let Some(page_number) = page_number else {
-    return None;
-  };
+  let page_number = page_number?;
   if title.is_empty() {
     return None;
   }

--- a/cli-justify/src/pdf_hybrid/structure/toc_patterns.rs
+++ b/cli-justify/src/pdf_hybrid/structure/toc_patterns.rs
@@ -33,13 +33,13 @@ pub(crate) fn looks_like_toc_entry_prefix(prefix: &str) -> bool {
 #[derive(Clone, Copy)]
 pub(crate) enum TocPrefixKind {
   /// Like `1.2.3` — a bare dotted-numeric or alphanumeric section identifier.
-  NumericSectionLabel,
+  NumericSection,
   /// Like `Appendix A` — a recognized TOC keyword followed by a counter token.
-  KeywordedLabel,
+  Keyworded,
   /// Like `Plate 14` — a title-case word followed by a numeric counter.
   /// More permissive but requires a strictly numeric counter to avoid
   /// matching multi-column rows like `Akrom K`.
-  TitleNumberLabel,
+  TitleNumber,
 }
 
 pub(crate) fn classify_toc_entry_prefix(prefix: &str) -> Option<TocPrefixKind> {
@@ -51,7 +51,7 @@ pub(crate) fn classify_toc_entry_prefix(prefix: &str) -> Option<TocPrefixKind> {
   let words: Vec<&str> = prefix.split_whitespace().collect();
   if words.len() == 1 {
     if is_numeric_section_label(words[0]) {
-      return Some(TocPrefixKind::NumericSectionLabel);
+      return Some(TocPrefixKind::NumericSection);
     }
     return None;
   }
@@ -60,14 +60,14 @@ pub(crate) fn classify_toc_entry_prefix(prefix: &str) -> Option<TocPrefixKind> {
     && is_toc_label_keyword(words[0])
     && is_counter_token(words[1])
   {
-    return Some(TocPrefixKind::KeywordedLabel);
+    return Some(TocPrefixKind::Keyworded);
   }
 
   if words.len() == 2
     && is_title_case_label_word(words[0])
     && is_numeric_counter(words[1])
   {
-    return Some(TocPrefixKind::TitleNumberLabel);
+    return Some(TocPrefixKind::TitleNumber);
   }
 
   None

--- a/cli-justify/src/pdf_hybrid/wrapping.rs
+++ b/cli-justify/src/pdf_hybrid/wrapping.rs
@@ -265,11 +265,7 @@ pub(super) fn wrap_aligned_toc_row(
   let continuation_limit =
     line_width.saturating_sub(char_len(&continuation_prefix));
 
-  loop {
-    let Some(last_line) = wrapped.last() else {
-      break;
-    };
-
+  while let Some(last_line) = wrapped.last() {
     let last_idx = wrapped.len() - 1;
     let prefix_len = if last_idx == 0 {
       char_len(&first_prefix)
@@ -337,9 +333,7 @@ pub(super) fn flush_pending_pdf_block(
   out: &mut Vec<String>,
   line_width: usize,
 ) -> Option<usize> {
-  let Some(block) = pending.take() else {
-    return None;
-  };
+  let block = pending.take()?;
 
   match block {
     PendingPdfBlock::Paragraph { indent, lines } => {

--- a/cli-pdf-to-text/src/ocr.rs
+++ b/cli-pdf-to-text/src/ocr.rs
@@ -189,7 +189,7 @@ fn ocr_missing_text_regions(
       let Some(bbox) = image.bbox() else {
         continue;
       };
-      let Some(region) = TextRegion::from_rect(&bbox) else {
+      let Some(region) = TextRegion::from_rect(bbox) else {
         continue;
       };
       if native_region_text_is_sufficient(native_regions, &region) {

--- a/cli-pdf-to-text/src/stream.rs
+++ b/cli-pdf-to-text/src/stream.rs
@@ -884,7 +884,7 @@ fn compose_visual_page(
           continue;
         }
         let indent =
-          (((row.left - page_left) / 5.0).round()).max(0.0).min(20.0) as usize;
+          (((row.left - page_left) / 5.0).round()).clamp(0.0, 20.0) as usize;
         let text_width = col.saturating_sub(indent).max(1);
         let wrapped_lines = if row.text.chars().count() <= text_width {
           vec![row.text]

--- a/cli-text-reader/Cargo.toml
+++ b/cli-text-reader/Cargo.toml
@@ -31,11 +31,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dotenvy = "0.15"
 ureq = { version = "3", features = ["json"] }
 
-arboard = { version = "3", default-features = true }
-[target.'cfg(target_os = "linux")'.dependencies.arboard]
-version = "3"
-default-features = true
-features = ["wayland-data-control"]
+arboard = { version = "3", default-features = true, features = ["wayland-data-control"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/cli-text-reader/src/editor/commands.rs
+++ b/cli-text-reader/src/editor/commands.rs
@@ -195,6 +195,19 @@ impl Editor {
   }
 }
 
+// Handle Vim-style commands
+pub fn handle_command(command: &str, show_highlighter: &mut bool) -> bool {
+  match command.trim() {
+    "q" => true,
+    "z" => {
+      *show_highlighter = !*show_highlighter;
+      false
+    }
+    "p" | "help" | "tutorial" => false,
+    _ => false,
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::Editor;
@@ -224,18 +237,5 @@ mod tests {
       assert!(!editor.ocr_enabled);
       assert_eq!(editor.buffers.len(), 1);
     }
-  }
-}
-
-// Handle Vim-style commands
-pub fn handle_command(command: &str, show_highlighter: &mut bool) -> bool {
-  match command.trim() {
-    "q" => true,
-    "z" => {
-      *show_highlighter = !*show_highlighter;
-      false
-    }
-    "p" | "help" | "tutorial" => false,
-    _ => false,
   }
 }

--- a/cli-text-reader/src/editor/core.rs
+++ b/cli-text-reader/src/editor/core.rs
@@ -55,260 +55,6 @@ fn reanchored_pdf_line(
   line + clamped_line_in_page
 }
 
-#[cfg(test)]
-mod tests {
-  use super::*;
-  use crate::editor::streaming::{
-    LoadedPage, PageLoaded, PageSlot, PdfStreamingState,
-  };
-  use cli_pdf_to_text::{PdfRenderedPage, PdfStream};
-  use std::sync::atomic::AtomicBool;
-  use std::sync::{Arc, mpsc};
-
-  fn test_pdf_stream() -> Option<Arc<PdfStream>> {
-    let pdf_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-      .join("../test-data/pdf/progit-1-50.pdf");
-    if !pdf_path.exists() {
-      return None;
-    }
-    Some(Arc::new(
-      PdfStream::open(pdf_path.to_str().expect("utf-8 path"))
-        .expect("PdfStream should open valid test PDF"),
-    ))
-  }
-
-  fn rendered_image_page(lines: &[&str]) -> PdfRenderedPage {
-    PdfRenderedPage {
-      raw_text: lines.join("\n"),
-      lines: lines.iter().map(|line| (*line).to_string()).collect(),
-      line_kinds: vec![PdfLineKind::Text; lines.len()],
-      contains_images: true,
-    }
-  }
-
-  fn editor_with_two_page_pdf() -> Option<(Editor, mpsc::SyncSender<PageLoaded>)>
-  {
-    let stream = test_pdf_stream()?;
-    let (tx, rx) = mpsc::sync_channel(4);
-    let mut editor = Editor::new(vec!["placeholder".to_string()], 80);
-    editor.height = 10;
-    editor.ocr_enabled = true;
-    editor.pdf_streaming = Some(PdfStreamingState {
-      stream,
-      col: 80,
-      pages: vec![
-        PageSlot::Loaded(LoadedPage::from_rendered(
-          rendered_image_page(&["p1-0", "p1-1", "p1-2"]),
-          80,
-        )),
-        PageSlot::Loaded(LoadedPage::from_rendered(
-          rendered_image_page(&["p2-0", "p2-1"]),
-          80,
-        )),
-      ],
-      receiver: rx,
-      cancel: Arc::new(AtomicBool::new(false)),
-      fully_loaded: true,
-      ocr_loading: true,
-      ocr_receiver: None,
-      ocr_cancel: None,
-      ocr_worker: None,
-      worker: None,
-    });
-    editor.rebuild_lines_from_pdf_stream();
-    Some((editor, tx))
-  }
-
-  #[test]
-  fn pdf_restore_uses_saved_cursor_screen_row() {
-    assert_eq!(restored_pdf_viewport(42, 24, Some(14)), (28, 14));
-  }
-
-  #[test]
-  fn pdf_restore_clamps_saved_cursor_row_near_top() {
-    assert_eq!(restored_pdf_viewport(3, 24, Some(14)), (0, 3));
-  }
-
-  #[test]
-  fn pdf_restore_falls_back_to_center_without_saved_cursor_row() {
-    assert_eq!(restored_pdf_viewport(42, 24, None), (30, 12));
-  }
-
-  #[test]
-  fn drain_pdf_stream_replaces_loaded_page_for_ocr_update() {
-    let pdf_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-      .join("../test-data/pdf/progit-1-50.pdf");
-    if !pdf_path.exists() {
-      return;
-    }
-    let stream = Arc::new(
-      PdfStream::open(pdf_path.to_str().expect("utf-8 path"))
-        .expect("PdfStream should open valid test PDF"),
-    );
-    let (tx, rx) = mpsc::sync_channel(1);
-    let mut editor = Editor::new(vec!["fast page".to_string()], 80);
-    editor.ocr_enabled = true;
-    editor.pdf_streaming = Some(PdfStreamingState {
-      stream,
-      col: 80,
-      pages: vec![PageSlot::Loaded(LoadedPage::from_raw(
-        "fast page".to_string(),
-        80,
-      ))],
-      receiver: rx,
-      cancel: Arc::new(AtomicBool::new(false)),
-      fully_loaded: true,
-      ocr_loading: true,
-      ocr_receiver: None,
-      ocr_cancel: None,
-      ocr_worker: None,
-      worker: None,
-    });
-    editor.rebuild_lines_from_pdf_stream();
-
-    tx.send(PageLoaded::Page {
-      page_index: 0,
-      rendered_page: PdfRenderedPage {
-        raw_text: "ocr page".to_string(),
-        lines: vec!["ocr page".to_string()],
-        line_kinds: vec![PdfLineKind::Text],
-        contains_images: true,
-      },
-      replace_existing: true,
-    })
-    .expect("replacement page should enqueue");
-
-    assert_eq!(editor.drain_pdf_stream(), 1);
-    assert_eq!(editor.lines, vec!["ocr page"]);
-    let PageSlot::Loaded(page) =
-      &editor.pdf_streaming.as_ref().expect("streaming state").pages[0]
-    else {
-      panic!("page should be loaded");
-    };
-    assert!(page.ocr_enhanced);
-  }
-
-  #[test]
-  fn drain_pdf_stream_marks_ocr_complete() {
-    let pdf_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-      .join("../test-data/pdf/progit-1-50.pdf");
-    if !pdf_path.exists() {
-      return;
-    }
-    let stream = Arc::new(
-      PdfStream::open(pdf_path.to_str().expect("utf-8 path"))
-        .expect("PdfStream should open valid test PDF"),
-    );
-    let (tx, rx) = mpsc::sync_channel(1);
-    let mut editor = Editor::new(vec!["fast page".to_string()], 80);
-    editor.pdf_streaming = Some(PdfStreamingState {
-      stream,
-      col: 80,
-      pages: vec![PageSlot::Loaded(LoadedPage::from_raw(
-        "fast page".to_string(),
-        80,
-      ))],
-      receiver: rx,
-      cancel: Arc::new(AtomicBool::new(false)),
-      fully_loaded: true,
-      ocr_loading: true,
-      ocr_receiver: None,
-      ocr_cancel: None,
-      ocr_worker: None,
-      worker: None,
-    });
-
-    tx.send(PageLoaded::OcrComplete).expect("OCR completion should enqueue");
-
-    assert_eq!(editor.drain_pdf_stream(), 1);
-    assert!(
-      !editor.pdf_streaming.as_ref().expect("streaming state").ocr_loading
-    );
-  }
-
-  #[test]
-  fn ocr_replacement_preserves_page_line_and_cursor_screen_row() {
-    let Some((mut editor, tx)) = editor_with_two_page_pdf() else {
-      return;
-    };
-    editor.offset = 3;
-    editor.cursor_y = 2;
-    editor.buffers[0].offset = 3;
-    editor.buffers[0].cursor_y = 2;
-    assert_eq!(editor.current_pdf_position(), Some((2, 1)));
-
-    tx.send(PageLoaded::Page {
-      page_index: 0,
-      rendered_page: rendered_image_page(&["p1 replacement"]),
-      replace_existing: true,
-    })
-    .expect("replacement page should enqueue");
-
-    assert_eq!(editor.drain_pdf_stream(), 1);
-    assert_eq!(editor.current_pdf_position(), Some((2, 1)));
-    assert_eq!(editor.cursor_y, 2);
-    assert_eq!(editor.offset, 1);
-  }
-
-  #[test]
-  fn drain_pdf_stream_updates_pdf_buffer_without_moving_overlay() {
-    assert_non_pdf_active_drain_preserves_active_buffer(ViewMode::Overlay);
-  }
-
-  #[test]
-  fn drain_pdf_stream_updates_pdf_buffer_without_moving_split() {
-    assert_non_pdf_active_drain_preserves_active_buffer(
-      ViewMode::HorizontalSplit,
-    );
-  }
-
-  fn assert_non_pdf_active_drain_preserves_active_buffer(view_mode: ViewMode) {
-    let Some((mut editor, tx)) = editor_with_two_page_pdf() else {
-      return;
-    };
-    editor.buffers[0].offset = 3;
-    editor.buffers[0].cursor_y = 2;
-
-    let mut panel = BufferState::new(vec![
-      "panel-0".to_string(),
-      "panel-1".to_string(),
-      "panel-2".to_string(),
-      "panel-3".to_string(),
-    ]);
-    panel.offset = 1;
-    panel.cursor_y = 1;
-    panel.viewport_height = 4;
-    panel.is_split_buffer = view_mode == ViewMode::HorizontalSplit;
-    editor.buffers.push(panel);
-    editor.active_buffer = 1;
-    editor.active_pane = 1;
-    editor.view_mode = view_mode.clone();
-    editor.load_buffer_state(1);
-    let active_lines = editor.lines.clone();
-    let active_offset = editor.offset;
-    let active_cursor_y = editor.cursor_y;
-    let active_total_lines = editor.total_lines;
-
-    tx.send(PageLoaded::Page {
-      page_index: 0,
-      rendered_page: rendered_image_page(&["p1 replacement"]),
-      replace_existing: true,
-    })
-    .expect("replacement page should enqueue");
-
-    assert_eq!(editor.drain_pdf_stream(), 1);
-    assert_eq!(editor.active_buffer, 1);
-    assert_eq!(editor.view_mode, view_mode);
-    assert_eq!(editor.lines, active_lines);
-    assert_eq!(editor.offset, active_offset);
-    assert_eq!(editor.cursor_y, active_cursor_y);
-    assert_eq!(editor.total_lines, active_total_lines);
-    assert_eq!(editor.buffers[0].lines[0], "p1 replacement");
-    assert_eq!(editor.buffers[0].offset, 1);
-    assert_eq!(editor.buffers[0].cursor_y, 2);
-  }
-}
-
 fn restored_pdf_viewport(
   document_line: usize,
   content_height: usize,
@@ -1007,5 +753,259 @@ impl Editor {
     } else {
       self.height.saturating_sub(1)
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::editor::streaming::{
+    LoadedPage, PageLoaded, PageSlot, PdfStreamingState,
+  };
+  use cli_pdf_to_text::{PdfRenderedPage, PdfStream};
+  use std::sync::atomic::AtomicBool;
+  use std::sync::{Arc, mpsc};
+
+  fn test_pdf_stream() -> Option<Arc<PdfStream>> {
+    let pdf_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+      .join("../test-data/pdf/progit-1-50.pdf");
+    if !pdf_path.exists() {
+      return None;
+    }
+    Some(Arc::new(
+      PdfStream::open(pdf_path.to_str().expect("utf-8 path"))
+        .expect("PdfStream should open valid test PDF"),
+    ))
+  }
+
+  fn rendered_image_page(lines: &[&str]) -> PdfRenderedPage {
+    PdfRenderedPage {
+      raw_text: lines.join("\n"),
+      lines: lines.iter().map(|line| (*line).to_string()).collect(),
+      line_kinds: vec![PdfLineKind::Text; lines.len()],
+      contains_images: true,
+    }
+  }
+
+  fn editor_with_two_page_pdf() -> Option<(Editor, mpsc::SyncSender<PageLoaded>)>
+  {
+    let stream = test_pdf_stream()?;
+    let (tx, rx) = mpsc::sync_channel(4);
+    let mut editor = Editor::new(vec!["placeholder".to_string()], 80);
+    editor.height = 10;
+    editor.ocr_enabled = true;
+    editor.pdf_streaming = Some(PdfStreamingState {
+      stream,
+      col: 80,
+      pages: vec![
+        PageSlot::Loaded(LoadedPage::from_rendered(
+          rendered_image_page(&["p1-0", "p1-1", "p1-2"]),
+          80,
+        )),
+        PageSlot::Loaded(LoadedPage::from_rendered(
+          rendered_image_page(&["p2-0", "p2-1"]),
+          80,
+        )),
+      ],
+      receiver: rx,
+      cancel: Arc::new(AtomicBool::new(false)),
+      fully_loaded: true,
+      ocr_loading: true,
+      ocr_receiver: None,
+      ocr_cancel: None,
+      ocr_worker: None,
+      worker: None,
+    });
+    editor.rebuild_lines_from_pdf_stream();
+    Some((editor, tx))
+  }
+
+  #[test]
+  fn pdf_restore_uses_saved_cursor_screen_row() {
+    assert_eq!(restored_pdf_viewport(42, 24, Some(14)), (28, 14));
+  }
+
+  #[test]
+  fn pdf_restore_clamps_saved_cursor_row_near_top() {
+    assert_eq!(restored_pdf_viewport(3, 24, Some(14)), (0, 3));
+  }
+
+  #[test]
+  fn pdf_restore_falls_back_to_center_without_saved_cursor_row() {
+    assert_eq!(restored_pdf_viewport(42, 24, None), (30, 12));
+  }
+
+  #[test]
+  fn drain_pdf_stream_replaces_loaded_page_for_ocr_update() {
+    let pdf_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+      .join("../test-data/pdf/progit-1-50.pdf");
+    if !pdf_path.exists() {
+      return;
+    }
+    let stream = Arc::new(
+      PdfStream::open(pdf_path.to_str().expect("utf-8 path"))
+        .expect("PdfStream should open valid test PDF"),
+    );
+    let (tx, rx) = mpsc::sync_channel(1);
+    let mut editor = Editor::new(vec!["fast page".to_string()], 80);
+    editor.ocr_enabled = true;
+    editor.pdf_streaming = Some(PdfStreamingState {
+      stream,
+      col: 80,
+      pages: vec![PageSlot::Loaded(LoadedPage::from_raw(
+        "fast page".to_string(),
+        80,
+      ))],
+      receiver: rx,
+      cancel: Arc::new(AtomicBool::new(false)),
+      fully_loaded: true,
+      ocr_loading: true,
+      ocr_receiver: None,
+      ocr_cancel: None,
+      ocr_worker: None,
+      worker: None,
+    });
+    editor.rebuild_lines_from_pdf_stream();
+
+    tx.send(PageLoaded::Page {
+      page_index: 0,
+      rendered_page: PdfRenderedPage {
+        raw_text: "ocr page".to_string(),
+        lines: vec!["ocr page".to_string()],
+        line_kinds: vec![PdfLineKind::Text],
+        contains_images: true,
+      },
+      replace_existing: true,
+    })
+    .expect("replacement page should enqueue");
+
+    assert_eq!(editor.drain_pdf_stream(), 1);
+    assert_eq!(editor.lines, vec!["ocr page"]);
+    let PageSlot::Loaded(page) =
+      &editor.pdf_streaming.as_ref().expect("streaming state").pages[0]
+    else {
+      panic!("page should be loaded");
+    };
+    assert!(page.ocr_enhanced);
+  }
+
+  #[test]
+  fn drain_pdf_stream_marks_ocr_complete() {
+    let pdf_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+      .join("../test-data/pdf/progit-1-50.pdf");
+    if !pdf_path.exists() {
+      return;
+    }
+    let stream = Arc::new(
+      PdfStream::open(pdf_path.to_str().expect("utf-8 path"))
+        .expect("PdfStream should open valid test PDF"),
+    );
+    let (tx, rx) = mpsc::sync_channel(1);
+    let mut editor = Editor::new(vec!["fast page".to_string()], 80);
+    editor.pdf_streaming = Some(PdfStreamingState {
+      stream,
+      col: 80,
+      pages: vec![PageSlot::Loaded(LoadedPage::from_raw(
+        "fast page".to_string(),
+        80,
+      ))],
+      receiver: rx,
+      cancel: Arc::new(AtomicBool::new(false)),
+      fully_loaded: true,
+      ocr_loading: true,
+      ocr_receiver: None,
+      ocr_cancel: None,
+      ocr_worker: None,
+      worker: None,
+    });
+
+    tx.send(PageLoaded::OcrComplete).expect("OCR completion should enqueue");
+
+    assert_eq!(editor.drain_pdf_stream(), 1);
+    assert!(
+      !editor.pdf_streaming.as_ref().expect("streaming state").ocr_loading
+    );
+  }
+
+  #[test]
+  fn ocr_replacement_preserves_page_line_and_cursor_screen_row() {
+    let Some((mut editor, tx)) = editor_with_two_page_pdf() else {
+      return;
+    };
+    editor.offset = 3;
+    editor.cursor_y = 2;
+    editor.buffers[0].offset = 3;
+    editor.buffers[0].cursor_y = 2;
+    assert_eq!(editor.current_pdf_position(), Some((2, 1)));
+
+    tx.send(PageLoaded::Page {
+      page_index: 0,
+      rendered_page: rendered_image_page(&["p1 replacement"]),
+      replace_existing: true,
+    })
+    .expect("replacement page should enqueue");
+
+    assert_eq!(editor.drain_pdf_stream(), 1);
+    assert_eq!(editor.current_pdf_position(), Some((2, 1)));
+    assert_eq!(editor.cursor_y, 2);
+    assert_eq!(editor.offset, 1);
+  }
+
+  #[test]
+  fn drain_pdf_stream_updates_pdf_buffer_without_moving_overlay() {
+    assert_non_pdf_active_drain_preserves_active_buffer(ViewMode::Overlay);
+  }
+
+  #[test]
+  fn drain_pdf_stream_updates_pdf_buffer_without_moving_split() {
+    assert_non_pdf_active_drain_preserves_active_buffer(
+      ViewMode::HorizontalSplit,
+    );
+  }
+
+  fn assert_non_pdf_active_drain_preserves_active_buffer(view_mode: ViewMode) {
+    let Some((mut editor, tx)) = editor_with_two_page_pdf() else {
+      return;
+    };
+    editor.buffers[0].offset = 3;
+    editor.buffers[0].cursor_y = 2;
+
+    let mut panel = BufferState::new(vec![
+      "panel-0".to_string(),
+      "panel-1".to_string(),
+      "panel-2".to_string(),
+      "panel-3".to_string(),
+    ]);
+    panel.offset = 1;
+    panel.cursor_y = 1;
+    panel.viewport_height = 4;
+    panel.is_split_buffer = view_mode == ViewMode::HorizontalSplit;
+    editor.buffers.push(panel);
+    editor.active_buffer = 1;
+    editor.active_pane = 1;
+    editor.view_mode = view_mode.clone();
+    editor.load_buffer_state(1);
+    let active_lines = editor.lines.clone();
+    let active_offset = editor.offset;
+    let active_cursor_y = editor.cursor_y;
+    let active_total_lines = editor.total_lines;
+
+    tx.send(PageLoaded::Page {
+      page_index: 0,
+      rendered_page: rendered_image_page(&["p1 replacement"]),
+      replace_existing: true,
+    })
+    .expect("replacement page should enqueue");
+
+    assert_eq!(editor.drain_pdf_stream(), 1);
+    assert_eq!(editor.active_buffer, 1);
+    assert_eq!(editor.view_mode, view_mode);
+    assert_eq!(editor.lines, active_lines);
+    assert_eq!(editor.offset, active_offset);
+    assert_eq!(editor.cursor_y, active_cursor_y);
+    assert_eq!(editor.total_lines, active_total_lines);
+    assert_eq!(editor.buffers[0].lines[0], "p1 replacement");
+    assert_eq!(editor.buffers[0].offset, 1);
+    assert_eq!(editor.buffers[0].cursor_y, 2);
   }
 }

--- a/cli-text-reader/src/editor/highlighting_selection.rs
+++ b/cli-text-reader/src/editor/highlighting_selection.rs
@@ -15,14 +15,12 @@ impl Editor {
     line: &str,
     center_offset_string: &str,
   ) -> IoResult<bool> {
-    if ((self.editor_state.mode == EditorMode::VisualChar
+    if (self.editor_state.mode == EditorMode::VisualChar
       || self.editor_state.mode == EditorMode::VisualLine
       || self.editor_state.visual_selection_active)
-      && self.editor_state.selection_start.is_some()
-      && self.editor_state.selection_end.is_some())
+      && let (Some(start), Some(end)) =
+        (self.editor_state.selection_start, self.editor_state.selection_end)
     {
-      let start = self.editor_state.selection_start.unwrap();
-      let end = self.editor_state.selection_end.unwrap();
       let current_line_idx = self.offset + line_index;
 
       // Determine if this line is within the selection range
@@ -152,14 +150,12 @@ impl Editor {
     line: &str,
     center_offset_string: &str,
   ) -> IoResult<bool> {
-    if ((self.editor_state.mode == EditorMode::VisualChar
+    if (self.editor_state.mode == EditorMode::VisualChar
       || self.editor_state.mode == EditorMode::VisualLine
       || self.editor_state.visual_selection_active)
-      && self.editor_state.selection_start.is_some()
-      && self.editor_state.selection_end.is_some())
+      && let (Some(start), Some(end)) =
+        (self.editor_state.selection_start, self.editor_state.selection_end)
     {
-      let start = self.editor_state.selection_start.unwrap();
-      let end = self.editor_state.selection_end.unwrap();
       let current_line_idx = self.offset + line_index;
 
       // Determine if this line is within the selection range

--- a/cli-text-reader/src/editor/yank.rs
+++ b/cli-text-reader/src/editor/yank.rs
@@ -17,27 +17,6 @@ fn osc52_copy(text: &str) {
   let _ = stdout.flush();
 }
 
-#[cfg(test)]
-mod tests {
-  use super::*;
-  use cli_pdf_to_text::PdfLineKind;
-
-  #[test]
-  fn yank_line_skips_ansi_art_rows() {
-    let mut editor = Editor::new(
-      vec!["plain".to_string(), "\x1b[38;2;1;2;3m▀\x1b[0m".to_string()],
-      80,
-    );
-    editor.line_kinds = vec![PdfLineKind::Text, PdfLineKind::AnsiArt];
-    editor.editor_state.yank_buffer = "previous".to_string();
-    editor.cursor_y = 1;
-
-    editor.yank_line();
-
-    assert_eq!(editor.editor_state.yank_buffer, "previous");
-  }
-}
-
 fn base64_encode(input: &[u8]) -> String {
   const ALPHABET: &[u8; 64] =
     b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -187,5 +166,26 @@ impl Editor {
         }
       }
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use cli_pdf_to_text::PdfLineKind;
+
+  #[test]
+  fn yank_line_skips_ansi_art_rows() {
+    let mut editor = Editor::new(
+      vec!["plain".to_string(), "\x1b[38;2;1;2;3m▀\x1b[0m".to_string()],
+      80,
+    );
+    editor.line_kinds = vec![PdfLineKind::Text, PdfLineKind::AnsiArt];
+    editor.editor_state.yank_buffer = "previous".to_string();
+    editor.cursor_y = 1;
+
+    editor.yank_line();
+
+    assert_eq!(editor.editor_state.yank_buffer, "previous");
   }
 }

--- a/hygg/tests/integration_test.rs
+++ b/hygg/tests/integration_test.rs
@@ -299,13 +299,11 @@ fn test_epub_processing() {
 
   // Check if it panicked (would have exited with error)
   match child.try_wait() {
-    Ok(Some(status)) => {
-      if !status.success() {
-        let stderr = child.wait_with_output().unwrap().stderr;
-        let stderr_str = String::from_utf8_lossy(&stderr);
-        if stderr_str.contains("panic") {
-          panic!("hygg panicked: {}", stderr_str);
-        }
+    Ok(Some(status)) if !status.success() => {
+      let stderr = child.wait_with_output().unwrap().stderr;
+      let stderr_str = String::from_utf8_lossy(&stderr);
+      if stderr_str.contains("panic") {
+        panic!("hygg panicked: {}", stderr_str);
       }
     }
     _ => {
@@ -399,13 +397,11 @@ fn test_docx_processing_with_pandoc() {
 
   // Check if it panicked
   match child.try_wait() {
-    Ok(Some(status)) => {
-      if !status.success() {
-        let stderr = child.wait_with_output().unwrap().stderr;
-        let stderr_str = String::from_utf8_lossy(&stderr);
-        if stderr_str.contains("panic") {
-          panic!("hygg panicked on DOCX: {}", stderr_str);
-        }
+    Ok(Some(status)) if !status.success() => {
+      let stderr = child.wait_with_output().unwrap().stderr;
+      let stderr_str = String::from_utf8_lossy(&stderr);
+      if stderr_str.contains("panic") {
+        panic!("hygg panicked on DOCX: {}", stderr_str);
       }
     }
     _ => {


### PR DESCRIPTION
## Summary

- Updates `ci.sh` so the active Clippy CI step runs all targets and all features with `-D warnings`.
- Fixes the warnings exposed by strict Clippy across `cli-justify`, `cli-pdf-to-text`, `cli-text-reader`, and `hygg` tests.
- Consolidates the `arboard` dependency declaration to avoid the `cargo udeps` duplicate-package warning.

## Validation

- `./ci.sh`
