### PR TITLE
feat(status-line): optional page number in status bar

### DIFF
--- a/cli-text-reader/src/config.rs
+++ b/cli-text-reader/src/config.rs
@@ -11,6 +11,7 @@ pub struct AppConfig {
   pub enable_line_highlighter: Option<bool>,
   pub show_cursor: Option<bool>,
   pub show_progress: Option<bool>,
+  pub show_page_numbers: Option<bool>,
   pub pdf_ocr: Option<bool>,
   pub tutorial_shown: Option<bool>,
 }
@@ -23,7 +24,7 @@ fn ensure_config_file() -> Result<(), Box<dyn std::error::Error>> {
   let config_path = get_config_env_path()?;
   ensure_config_file_with_defaults(
     &config_path,
-    "ENABLE_TUTORIAL=true\nENABLE_LINE_HIGHLIGHTER=true\nSHOW_CURSOR=true\nSHOW_PROGRESS=true\nPDF_OCR=false\nTUTORIAL_SHOWN=false\n",
+    "ENABLE_TUTORIAL=true\nENABLE_LINE_HIGHLIGHTER=true\nSHOW_CURSOR=true\nSHOW_PROGRESS=true\nSHOW_PAGE_NUMBERS=false\nPDF_OCR=false\nTUTORIAL_SHOWN=false\n",
   )
 }
 
@@ -42,6 +43,7 @@ pub fn load_config() -> AppConfig {
       config_bool("ENABLE_LINE_HIGHLIGHTER", &file_values);
     config.show_cursor = config_bool("SHOW_CURSOR", &file_values);
     config.show_progress = config_bool("SHOW_PROGRESS", &file_values);
+    config.show_page_numbers = config_bool("SHOW_PAGE_NUMBERS", &file_values);
     config.pdf_ocr = config_bool("PDF_OCR", &file_values);
     config.tutorial_shown = config_bool("TUTORIAL_SHOWN", &file_values);
   }
@@ -113,12 +115,16 @@ pub fn save_config(
     config.show_cursor.or(existing_config.show_cursor).unwrap_or(true);
   let show_progress =
     config.show_progress.or(existing_config.show_progress).unwrap_or(true);
+  let show_page_numbers = config
+    .show_page_numbers
+    .or(existing_config.show_page_numbers)
+    .unwrap_or(false);
   let pdf_ocr = config.pdf_ocr.or(existing_config.pdf_ocr).unwrap_or(false);
   let tutorial_shown =
     config.tutorial_shown.or(existing_config.tutorial_shown).unwrap_or(false);
 
   let content = format!(
-    "ENABLE_TUTORIAL={enable_tutorial}\nENABLE_LINE_HIGHLIGHTER={enable_line_highlighter}\nSHOW_CURSOR={show_cursor}\nSHOW_PROGRESS={show_progress}\nPDF_OCR={pdf_ocr}\nTUTORIAL_SHOWN={tutorial_shown}\n"
+    "ENABLE_TUTORIAL={enable_tutorial}\nENABLE_LINE_HIGHLIGHTER={enable_line_highlighter}\nSHOW_CURSOR={show_cursor}\nSHOW_PROGRESS={show_progress}\nSHOW_PAGE_NUMBERS={show_page_numbers}\nPDF_OCR={pdf_ocr}\nTUTORIAL_SHOWN={tutorial_shown}\n"
   );
 
   fs::write(config_path, content)?;

--- a/cli-text-reader/src/core_state.rs
+++ b/cli-text-reader/src/core_state.rs
@@ -26,6 +26,7 @@ pub struct Editor {
   #[allow(dead_code)]
   pub progress_display_until: Option<Instant>,
   pub show_progress: bool,
+  pub show_page_numbers: bool,
   pub cursor_x: usize,
   pub cursor_y: usize,
   pub clipboard: Option<Clipboard>,

--- a/cli-text-reader/src/editor/command_registry/types.rs
+++ b/cli-text-reader/src/editor/command_registry/types.rs
@@ -18,6 +18,7 @@ pub(crate) enum RegisteredCommand {
   NoHighlight,
   NoTutorial,
   Ocr(bool),
+  PageNumbers,
   Progress,
   Quit,
   Shell(String),
@@ -80,6 +81,8 @@ pub(crate) const COMMANDS: &[CommandSpec] = &[
   CommandSpec { name: "notutorial", arguments: &[] },
   CommandSpec { name: "ocr", arguments: OCR_ARGS },
   CommandSpec { name: "p", arguments: &[] },
+  CommandSpec { name: "pagenumbers", arguments: &[] },
+  CommandSpec { name: "pn", arguments: &[] },
   CommandSpec { name: "prev", arguments: &[] },
   CommandSpec { name: "previous", arguments: &[] },
   CommandSpec { name: "q", arguments: &[] },
@@ -109,6 +112,7 @@ pub(crate) fn classify_command(input: &str) -> RegisteredCommand {
 
   match (command, args.as_slice()) {
     ("p", []) => RegisteredCommand::Progress,
+    ("pagenumbers" | "pn", []) => RegisteredCommand::PageNumbers,
     ("cursor" | "c", []) => RegisteredCommand::Cursor,
     ("help" | "commands", []) => RegisteredCommand::Help,
     ("notutorial", []) => RegisteredCommand::NoTutorial,
@@ -159,6 +163,8 @@ pub(crate) fn command_help_lines() -> Vec<String> {
     "    :back, :prev, :previous Previous tutorial step".to_string(),
     "    :z                     Toggle line highlighter".to_string(),
     "    :p                     Toggle progress display".to_string(),
+    "    :pagenumbers, :pn      Toggle page numbers in status bar (PDF only)"
+      .to_string(),
     "    :ocr on, :ocr off      Toggle PDF OCR for this PDF and future launches"
       .to_string(),
     "    :speak, :speak stop    Narrate from the cursor (any key stops)"

--- a/cli-text-reader/src/editor/command_registry_tests.rs
+++ b/cli-text-reader/src/editor/command_registry_tests.rs
@@ -66,6 +66,8 @@ fn registry_classifies_dispatch_commands() {
   assert_eq!(classify_command("ocr on"), RegisteredCommand::Ocr(true));
   assert_eq!(classify_command("ocr off"), RegisteredCommand::Ocr(false));
   assert_eq!(classify_command("ocron"), RegisteredCommand::Unknown);
+  assert_eq!(classify_command("pagenumbers"), RegisteredCommand::PageNumbers);
+  assert_eq!(classify_command("pn"), RegisteredCommand::PageNumbers);
   assert_eq!(
     classify_command("tutorial 3"),
     RegisteredCommand::Tutorial(TutorialCommand::Step(3))

--- a/cli-text-reader/src/editor/commands.rs
+++ b/cli-text-reader/src/editor/commands.rs
@@ -159,6 +159,7 @@ impl Editor {
 
     match registered_command {
       RegisteredCommand::Progress => self.handle_progress_command(),
+      RegisteredCommand::PageNumbers => self.handle_page_numbers_command(),
       RegisteredCommand::Cursor => self.handle_cursor_command(),
       RegisteredCommand::Help => self.handle_help_command(),
       RegisteredCommand::NoTutorial => self.handle_notutorial_command(),

--- a/cli-text-reader/src/editor/commands_handlers/config.rs
+++ b/cli-text-reader/src/editor/commands_handlers/config.rs
@@ -9,6 +9,7 @@ impl Editor {
       enable_line_highlighter: Some(self.show_highlighter),
       show_cursor: Some(self.show_cursor),
       show_progress: Some(self.show_progress),
+      show_page_numbers: Some(self.show_page_numbers),
       pdf_ocr: None,        // Keep existing value
       tutorial_shown: None, // Keep existing value
     };

--- a/cli-text-reader/src/editor/commands_handlers/display.rs
+++ b/cli-text-reader/src/editor/commands_handlers/display.rs
@@ -17,6 +17,22 @@ impl Editor {
     Ok(false)
   }
 
+  // Handle :pagenumbers / :pn command - toggle page numbers in the status bar
+  pub fn handle_page_numbers_command(
+    &mut self,
+  ) -> Result<bool, Box<dyn std::error::Error>> {
+    self.show_page_numbers = !self.show_page_numbers;
+    self.save_current_config();
+    self.set_active_mode(EditorMode::Normal);
+    self.editor_state.command_buffer.clear();
+    self.editor_state.command_cursor_pos = 0;
+    if let Some(buffer) = self.buffers.get_mut(self.active_buffer) {
+      buffer.command_buffer.clear();
+      buffer.command_cursor_pos = 0;
+    }
+    Ok(false)
+  }
+
   // Handle :cursor command - toggle cursor visibility
   pub fn handle_cursor_command(
     &mut self,

--- a/cli-text-reader/src/editor/commands_handlers/ocr.rs
+++ b/cli-text-reader/src/editor/commands_handlers/ocr.rs
@@ -23,6 +23,7 @@ impl Editor {
       enable_line_highlighter: None,
       show_cursor: None,
       show_progress: None,
+      show_page_numbers: None,
       pdf_ocr: Some(enable),
       tutorial_shown: None,
     };

--- a/cli-text-reader/src/editor/commands_handlers/tutorial_screens.rs
+++ b/cli-text-reader/src/editor/commands_handlers/tutorial_screens.rs
@@ -98,6 +98,7 @@ impl Editor {
       enable_line_highlighter: None, // Keep existing value
       show_cursor: None,             // Keep existing value
       show_progress: None,           // Keep existing value
+      show_page_numbers: None,       // Keep existing value
       pdf_ocr: None,                 // Keep existing value
       tutorial_shown: None,          // Keep existing value
     };
@@ -149,6 +150,7 @@ impl Editor {
       enable_line_highlighter: None, // Keep existing value
       show_cursor: None,             // Keep existing value
       show_progress: None,           // Keep existing value
+      show_page_numbers: None,       // Keep existing value
       pdf_ocr: None,                 // Keep existing value
       tutorial_shown: None,          // Keep existing value
     };

--- a/cli-text-reader/src/editor/core/constructor.rs
+++ b/cli-text-reader/src/editor/core/constructor.rs
@@ -87,6 +87,7 @@ impl Editor {
       total_lines,
       progress_display_until: None,
       show_progress: false,
+      show_page_numbers: false,
       cursor_x: 0,
       cursor_y: height / 2,
       clipboard,

--- a/cli-text-reader/src/editor/display_init.rs
+++ b/cli-text-reader/src/editor/display_init.rs
@@ -19,6 +19,7 @@ impl Editor {
     self.show_highlighter = config.enable_line_highlighter.unwrap_or(true);
     self.show_cursor = config.show_cursor.unwrap_or(true);
     self.show_progress = config.show_progress.unwrap_or(true);
+    self.show_page_numbers = config.show_page_numbers.unwrap_or(false);
 
     // Check if tutorial should be shown
     let tutorial_enabled = config.enable_tutorial.unwrap_or(true);

--- a/cli-text-reader/src/editor/status_line/layout.rs
+++ b/cli-text-reader/src/editor/status_line/layout.rs
@@ -1,0 +1,80 @@
+use std::io::{self, Write};
+
+use crossterm::{
+  QueueableCommand,
+  cursor::MoveTo,
+  terminal::{Clear, ClearType},
+};
+
+/// Contract every element of the right-anchored status bar must satisfy.
+///
+/// Declaring `reserved_width` is mandatory: the bar packs elements by these
+/// widths, so a new element cannot be added without sizing it, and an
+/// element's column never moves when only its *contents* change width. The
+/// reserved width may depend on editor state (e.g. the page count) but must be
+/// the widest the element can render in that state.
+pub(crate) trait StatusSlot {
+  /// Columns to reserve for this element, whether it renders this frame or
+  /// not — that is what keeps neighbouring elements from shifting.
+  fn reserved_width(&self) -> usize;
+
+  /// Text to draw this frame, or `None` to leave the reserved columns
+  /// untouched so document content shows through. It is right-aligned within
+  /// `reserved_width` and must never be wider than it.
+  fn render(&self) -> Option<String>;
+}
+
+/// Start column for each slot when packed right-to-left: the first slot's
+/// right edge sits `right_margin` columns from `terminal_width`, and each
+/// later slot is placed `gap` columns further left. Saturates at 0 so a narrow
+/// terminal clamps instead of underflowing.
+pub(crate) fn pack_right_anchored(
+  terminal_width: usize,
+  right_margin: usize,
+  gap: usize,
+  reserved: &[usize],
+) -> Vec<usize> {
+  let mut x = terminal_width.saturating_sub(right_margin);
+  let mut starts = Vec::with_capacity(reserved.len());
+  for (idx, &width) in reserved.iter().enumerate() {
+    if idx > 0 {
+      x = x.saturating_sub(gap);
+    }
+    x = x.saturating_sub(width);
+    starts.push(x);
+  }
+  starts
+}
+
+/// Draw a right-anchored row of fixed-width slots (given rightmost-first) at
+/// row `y`. Each rendered slot is right-aligned within its reserved width; the
+/// rightmost slot also clears to the end of the line when it renders, wiping
+/// the trailing margin.
+pub(crate) fn draw_right_anchored<W: Write>(
+  out: &mut W,
+  terminal_width: usize,
+  y: u16,
+  right_margin: usize,
+  gap: usize,
+  slots: &[&dyn StatusSlot],
+) -> io::Result<()> {
+  let reserved: Vec<usize> =
+    slots.iter().map(|slot| slot.reserved_width()).collect();
+  let starts =
+    pack_right_anchored(terminal_width, right_margin, gap, &reserved);
+
+  // Draw left-to-right so the rightmost slot (index 0) — the only one that
+  // clears to the end of the line — is written last.
+  for idx in (0..slots.len()).rev() {
+    let Some(text) = slots[idx].render() else {
+      continue;
+    };
+    let width = reserved[idx];
+    out.queue(MoveTo(starts[idx] as u16, y))?;
+    write!(out, "{text:>width$}")?;
+    if idx == 0 {
+      out.queue(Clear(ClearType::UntilNewLine))?;
+    }
+  }
+  Ok(())
+}

--- a/cli-text-reader/src/editor/status_line/mod.rs
+++ b/cli-text-reader/src/editor/status_line/mod.rs
@@ -1,4 +1,5 @@
 mod completion;
+mod layout;
 mod mode;
 mod progress;
 

--- a/cli-text-reader/src/editor/status_line/mode.rs
+++ b/cli-text-reader/src/editor/status_line/mode.rs
@@ -17,16 +17,7 @@ impl Editor {
     if self.view_mode == super::super::core::ViewMode::Normal
       && !self.tutorial_demo_mode
     {
-      if self.show_progress {
-        self.draw_progress_indicator(stdout)?;
-      } else {
-        let y = self.height as u16 - 2;
-        self.draw_pdf_loading_slots(
-          stdout,
-          self.progress_indicator_x() as u16,
-          y,
-        )?;
-      }
+      self.draw_status_bar(stdout)?;
     }
 
     Ok(())
@@ -146,16 +137,7 @@ impl Editor {
     if self.view_mode == super::super::core::ViewMode::Normal
       && !self.tutorial_demo_mode
     {
-      if self.show_progress {
-        self.draw_progress_indicator_buffered(buffer)?;
-      } else {
-        let y = self.height as u16 - 2;
-        self.draw_pdf_loading_slots_buffered(
-          buffer,
-          self.progress_indicator_x() as u16,
-          y,
-        )?;
-      }
+      self.draw_status_bar(buffer)?;
     }
 
     Ok(())

--- a/cli-text-reader/src/editor/status_line/progress.rs
+++ b/cli-text-reader/src/editor/status_line/progress.rs
@@ -1,13 +1,50 @@
-use crossterm::{QueueableCommand, cursor::MoveTo, execute};
+use crossterm::{cursor::MoveTo, execute};
 use std::io::{self, Write};
 
 use super::super::core::Editor;
+use super::layout::{StatusSlot, draw_right_anchored};
 
 pub(crate) const PDF_LOADING_SLOT_WIDTH: usize = 14; // "P[x] O[x] T[x]"
-// Blank columns kept to the right of the progress indicator so it never
-// touches the terminal edge.
+// Blank columns kept to the right of the status bar so it never touches the
+// terminal edge.
 const PROGRESS_RIGHT_MARGIN: usize = 2;
+// Blank columns between adjacent status-bar slots.
+const STATUS_SLOT_GAP: usize = 1;
 pub(crate) const PDF_LOADING_FRAMES: [&str; 4] = ["◰", "◳", "◲", "◱"];
+
+/// Reading position / page counter, drawn at the right edge of the status bar.
+struct ProgressSlot<'a> {
+  editor: &'a Editor,
+}
+
+impl StatusSlot for ProgressSlot<'_> {
+  fn reserved_width(&self) -> usize {
+    self.editor.progress_indicator_slot_width()
+  }
+
+  fn render(&self) -> Option<String> {
+    // Reserved even when hidden (so the loading slot beside it stays put), but
+    // only drawn when progress display is on.
+    self.editor.show_progress.then(|| self.editor.progress_indicator_message())
+  }
+}
+
+/// PDF parser / OCR / TTS loading spinners, drawn just left of the progress
+/// slot. Always reserves its full width so the progress slot never shifts as
+/// spinners come and go.
+struct PdfLoadingSlot<'a> {
+  editor: &'a Editor,
+}
+
+impl StatusSlot for PdfLoadingSlot<'_> {
+  fn reserved_width(&self) -> usize {
+    PDF_LOADING_SLOT_WIDTH
+  }
+
+  fn render(&self) -> Option<String> {
+    Some(self.editor.pdf_loading_slots_message())
+  }
+}
 
 impl Editor {
   // Draw position information in the status line
@@ -52,51 +89,31 @@ impl Editor {
     Ok(())
   }
 
-  // Draw progress indicator in the status line area
-  pub(crate) fn draw_progress_indicator(
+  /// Draw the right-anchored status bar (loading spinners + progress / page
+  /// counter). Works on any writer, so the immediate and buffered render paths
+  /// share one implementation. Slots are listed rightmost-first; each declares
+  /// its reserved width via `StatusSlot`, so adding a future element is just a
+  /// matter of implementing the trait and inserting it here.
+  pub(crate) fn draw_status_bar<W: Write>(
     &self,
-    stdout: &mut io::Stdout,
+    out: &mut W,
   ) -> io::Result<()> {
-    let message = self.progress_indicator_message();
-    let (slot, x) = self.progress_indicator_layout();
-
     self.debug_log(&format!(
-      "Drawing progress indicator: {} (view_mode: {:?}, demo: {})",
-      message, self.view_mode, self.tutorial_demo_mode
+      "Drawing status bar: {} (view_mode: {:?}, demo: {})",
+      self.progress_indicator_message(),
+      self.view_mode,
+      self.tutorial_demo_mode
     ));
-    let y = self.height as u16 - 2;
-    self.draw_pdf_loading_slots(stdout, x, y)?;
-    execute!(stdout, MoveTo(x, y))?;
-    write!(stdout, "{message:>slot$}")?;
-    execute!(
-      stdout,
-      crossterm::terminal::Clear(crossterm::terminal::ClearType::UntilNewLine)
-    )?;
-
-    Ok(())
-  }
-
-  // Buffered version of draw_progress_indicator
-  pub(crate) fn draw_progress_indicator_buffered(
-    &self,
-    buffer: &mut Vec<u8>,
-  ) -> io::Result<()> {
-    let message = self.progress_indicator_message();
-    let (slot, x) = self.progress_indicator_layout();
-
-    self.debug_log(&format!(
-      "Drawing progress indicator: {} (view_mode: {:?}, demo: {})",
-      message, self.view_mode, self.tutorial_demo_mode
-    ));
-    let y = self.height as u16 - 2;
-    self.draw_pdf_loading_slots_buffered(buffer, x, y)?;
-    buffer.queue(MoveTo(x, y))?;
-    write!(buffer, "{message:>slot$}")?;
-    buffer.queue(crossterm::terminal::Clear(
-      crossterm::terminal::ClearType::UntilNewLine,
-    ))?;
-
-    Ok(())
+    let progress = ProgressSlot { editor: self };
+    let loading = PdfLoadingSlot { editor: self };
+    draw_right_anchored(
+      out,
+      self.width,
+      self.height as u16 - 2,
+      PROGRESS_RIGHT_MARGIN,
+      STATUS_SLOT_GAP,
+      &[&progress, &loading],
+    )
   }
 
   pub(crate) fn progress_indicator_message(&self) -> String {
@@ -174,19 +191,6 @@ impl Editor {
     }
   }
 
-  /// Reserved slot width and the column to start drawing at, right-anchored
-  /// `PROGRESS_RIGHT_MARGIN` columns from the terminal edge.
-  pub(crate) fn progress_indicator_layout(&self) -> (usize, u16) {
-    let slot = self.progress_indicator_slot_width();
-    let x =
-      self.width.saturating_sub(slot).saturating_sub(PROGRESS_RIGHT_MARGIN);
-    (slot, x as u16)
-  }
-
-  pub(crate) fn progress_indicator_x(&self) -> usize {
-    self.progress_indicator_layout().1 as usize
-  }
-
   fn pdf_loading_slots_message(&self) -> String {
     let parser_loading = self.pdf_pending.is_some()
       || self.pdf_streaming.as_ref().is_some_and(|s| !s.fully_loaded);
@@ -209,36 +213,6 @@ impl Editor {
       tts_loading,
       frame_idx,
     )
-  }
-
-  fn pdf_loading_slots_x(&self) -> usize {
-    self.progress_indicator_x().saturating_sub(PDF_LOADING_SLOT_WIDTH + 1)
-  }
-
-  pub(crate) fn draw_pdf_loading_slots(
-    &self,
-    stdout: &mut io::Stdout,
-    progress_x: u16,
-    y: u16,
-  ) -> io::Result<()> {
-    let x = self.pdf_loading_slots_x().min(progress_x as usize) as u16;
-    let message = self.pdf_loading_slots_message();
-    execute!(stdout, MoveTo(x, y))?;
-    write!(stdout, "{message}")?;
-    Ok(())
-  }
-
-  pub(crate) fn draw_pdf_loading_slots_buffered(
-    &self,
-    buffer: &mut Vec<u8>,
-    progress_x: u16,
-    y: u16,
-  ) -> io::Result<()> {
-    let x = self.pdf_loading_slots_x().min(progress_x as usize) as u16;
-    let message = self.pdf_loading_slots_message();
-    buffer.queue(MoveTo(x, y))?;
-    write!(buffer, "{message}")?;
-    Ok(())
   }
 }
 

--- a/cli-text-reader/src/editor/status_line/progress.rs
+++ b/cli-text-reader/src/editor/status_line/progress.rs
@@ -3,8 +3,10 @@ use std::io::{self, Write};
 
 use super::super::core::Editor;
 
-pub(crate) const PROGRESS_SLOT_WIDTH: usize = 4;
 pub(crate) const PDF_LOADING_SLOT_WIDTH: usize = 14; // "P[x] O[x] T[x]"
+// Blank columns kept to the right of the progress indicator so it never
+// touches the terminal edge.
+const PROGRESS_RIGHT_MARGIN: usize = 2;
 pub(crate) const PDF_LOADING_FRAMES: [&str; 4] = ["◰", "◳", "◲", "◱"];
 
 impl Editor {
@@ -61,7 +63,7 @@ impl Editor {
       "Drawing progress indicator: {} (view_mode: {:?}, demo: {})",
       message, self.view_mode, self.tutorial_demo_mode
     ));
-    let x = self.progress_indicator_x() as u16;
+    let x = self.progress_indicator_x_for(message.chars().count()) as u16;
     let y = self.height as u16 - 2;
     self.draw_pdf_loading_slots(stdout, x, y)?;
     execute!(stdout, MoveTo(x, y))?;
@@ -85,7 +87,7 @@ impl Editor {
       "Drawing progress indicator: {} (view_mode: {:?}, demo: {})",
       message, self.view_mode, self.tutorial_demo_mode
     ));
-    let x = self.progress_indicator_x() as u16;
+    let x = self.progress_indicator_x_for(message.chars().count()) as u16;
     let y = self.height as u16 - 2;
     self.draw_pdf_loading_slots_buffered(buffer, x, y)?;
     buffer.queue(MoveTo(x, y))?;
@@ -101,25 +103,57 @@ impl Editor {
     if self.pdf_pending.is_some()
       || self.pdf_streaming.as_ref().is_some_and(|s| !s.fully_loaded)
     {
-      return format!("{:>width$}", "--%", width = PROGRESS_SLOT_WIDTH);
+      return "--%".to_string();
     }
 
-    // Calculate actual position in document (offset + cursor position + 1 for
-    // 1-based indexing)
+    let progress = self.read_progress_percent();
+
+    // PDFs carry a physical page structure readers navigate by, so show the
+    // absolute page alongside the percentage (e.g. `37/250 (18%)`). Flowed
+    // formats (EPUB, plain text, …) have no fixed pages and fall back to the
+    // percentage alone.
+    match self.current_page_indicator() {
+      Some((page, total_pages)) => {
+        format!("{page}/{total_pages} ({progress}%)")
+      }
+      None => format!("{progress}%"),
+    }
+  }
+
+  /// Reading progress as a whole-number percentage of lines consumed, clamped
+  /// to `0..=100`. An empty document counts as fully read.
+  fn read_progress_percent(&self) -> u32 {
+    if self.total_lines == 0 {
+      return 100;
+    }
+    // offset + cursor position, +1 for 1-based indexing.
     let current_position =
       (self.offset + self.cursor_y + 1).min(self.total_lines);
-    let progress = if self.total_lines > 0 {
-      (current_position as f64 / self.total_lines as f64 * 100.0)
-        .round()
-        .min(100.0)
-    } else {
-      100.0 // Empty document is 100% read
-    };
-    format!("{:>width$}", format!("{progress}%"), width = PROGRESS_SLOT_WIDTH)
+    ((current_position as f64 / self.total_lines as f64 * 100.0).round() as u32)
+      .min(100)
+  }
+
+  /// `(current_page_1based, total_pages)` for a streaming PDF whose page table
+  /// is known, or `None` for formats without physical pages.
+  fn current_page_indicator(&self) -> Option<(u32, usize)> {
+    let total_pages = self.pdf_streaming.as_ref()?.pages.len();
+    if total_pages == 0 {
+      return None;
+    }
+    let (page, _) = self.current_pdf_position()?;
+    Some((page, total_pages))
   }
 
   pub(crate) fn progress_indicator_x(&self) -> usize {
-    self.width.saturating_sub(PROGRESS_SLOT_WIDTH).saturating_sub(2)
+    self.progress_indicator_x_for(
+      self.progress_indicator_message().chars().count(),
+    )
+  }
+
+  /// Right-anchor a message of `message_len` columns, leaving
+  /// `PROGRESS_RIGHT_MARGIN` blank columns at the terminal edge.
+  pub(crate) fn progress_indicator_x_for(&self, message_len: usize) -> usize {
+    self.width.saturating_sub(message_len).saturating_sub(PROGRESS_RIGHT_MARGIN)
   }
 
   fn pdf_loading_slots_message(&self) -> String {

--- a/cli-text-reader/src/editor/status_line/progress.rs
+++ b/cli-text-reader/src/editor/status_line/progress.rs
@@ -10,7 +10,21 @@ pub(crate) const PDF_LOADING_SLOT_WIDTH: usize = 14; // "P[x] O[x] T[x]"
 const PROGRESS_RIGHT_MARGIN: usize = 2;
 // Blank columns between adjacent status-bar slots.
 const STATUS_SLOT_GAP: usize = 1;
+// Minimum digits reserved per number in the page counter. The real page count
+// is unknown while a PDF is opening, so the slot is sized for at least this
+// many digits up front (covers documents up to 9999 pages) and only grows for
+// larger ones — keeping the indicator from shifting on first load.
+const PAGE_COUNTER_MIN_DIGITS: usize = 4;
 pub(crate) const PDF_LOADING_FRAMES: [&str; 4] = ["◰", "◳", "◲", "◱"];
+
+/// Columns a `{page}/{total} (100%)` counter needs for `total` pages, never
+/// reserving fewer than `PAGE_COUNTER_MIN_DIGITS` digits per number so the
+/// width is stable before the real count is known.
+fn page_counter_width(total: usize) -> usize {
+  let digits = total.to_string().len().max(PAGE_COUNTER_MIN_DIGITS);
+  // "{d}/{d} (100%)": two numbers, a '/', and the literal " (100%)".
+  digits * 2 + 1 + " (100%)".len()
+}
 
 /// Reading position / page counter, drawn at the right edge of the status bar.
 struct ProgressSlot<'a> {
@@ -158,36 +172,43 @@ impl Editor {
       .min(100)
   }
 
-  /// `(current_page_1based, total_pages)` for a streaming PDF whose page table
-  /// is known, or `None` when the page counter is off or the format has no
-  /// physical pages.
+  /// `(current_page_1based, total_pages)` to actually render, or `None` when
+  /// the page counter is off or no real page table exists yet (the format has
+  /// no physical pages, or a PDF is still opening). Page numbers are only
+  /// available for PDFs, whose page table gives an authoritative count; flowed
+  /// formats (EPUB, DOCX, plain text, …) have no fixed pages.
   fn current_page_indicator(&self) -> Option<(u32, usize)> {
-    let total_pages = self.page_counter_total()?;
-    let (page, _) = self.current_pdf_position()?;
-    Some((page, total_pages))
-  }
-
-  /// Total page count to surface, or `None` when the page counter is disabled
-  /// (the default) or the document has no physical pages. Page numbers are
-  /// only available for PDFs, whose page table gives an authoritative count;
-  /// flowed formats (EPUB, DOCX, plain text, …) have no fixed pages.
-  fn page_counter_total(&self) -> Option<usize> {
     if !self.show_page_numbers {
       return None;
     }
     let total_pages = self.pdf_streaming.as_ref()?.pages.len();
-    (total_pages > 0).then_some(total_pages)
+    if total_pages == 0 {
+      return None;
+    }
+    let (page, _) = self.current_pdf_position()?;
+    Some((page, total_pages))
   }
 
-  /// Columns reserved for the progress indicator. When the page counter is
-  /// shown this is held at the widest it can reach for the current document
-  /// (`{total}/{total} (100%)`) so its left edge — and therefore the loading
-  /// spinners drawn beside it — stay put as the page, percentage, and loading
-  /// placeholder fill in. Otherwise it is just the percentage (`100%`).
+  /// Whether this session renders a PDF through the streaming pipeline — true
+  /// from the moment the open is kicked off (`pdf_pending`), before any page
+  /// table exists, through streaming and full load.
+  fn is_pdf_session(&self) -> bool {
+    self.pdf_pending.is_some() || self.pdf_streaming.is_some()
+  }
+
+  /// Columns reserved for the progress indicator, held stable for the whole
+  /// session so its left edge — and the loading spinners packed beside it —
+  /// never shift as contents fill in. With page numbers on for a PDF the real
+  /// count isn't known until the open finishes, so reserving the exact
+  /// `{total}/{total} (100%)` would jump the instant streaming begins; instead
+  /// reserve a digit-floored page counter that the real value only ever fills
+  /// into. Otherwise it is just the percentage (`100%`).
   pub(crate) fn progress_indicator_slot_width(&self) -> usize {
-    match self.page_counter_total() {
-      Some(total) => format!("{total}/{total} (100%)").len(),
-      None => "100%".len(),
+    if self.show_page_numbers && self.is_pdf_session() {
+      let total = self.pdf_streaming.as_ref().map_or(0, |s| s.pages.len());
+      page_counter_width(total)
+    } else {
+      "100%".len()
     }
   }
 

--- a/cli-text-reader/src/editor/status_line/progress.rs
+++ b/cli-text-reader/src/editor/status_line/progress.rs
@@ -58,16 +58,16 @@ impl Editor {
     stdout: &mut io::Stdout,
   ) -> io::Result<()> {
     let message = self.progress_indicator_message();
+    let (slot, x) = self.progress_indicator_layout();
 
     self.debug_log(&format!(
       "Drawing progress indicator: {} (view_mode: {:?}, demo: {})",
       message, self.view_mode, self.tutorial_demo_mode
     ));
-    let x = self.progress_indicator_x_for(message.chars().count()) as u16;
     let y = self.height as u16 - 2;
     self.draw_pdf_loading_slots(stdout, x, y)?;
     execute!(stdout, MoveTo(x, y))?;
-    write!(stdout, "{message}")?;
+    write!(stdout, "{message:>slot$}")?;
     execute!(
       stdout,
       crossterm::terminal::Clear(crossterm::terminal::ClearType::UntilNewLine)
@@ -82,16 +82,16 @@ impl Editor {
     buffer: &mut Vec<u8>,
   ) -> io::Result<()> {
     let message = self.progress_indicator_message();
+    let (slot, x) = self.progress_indicator_layout();
 
     self.debug_log(&format!(
       "Drawing progress indicator: {} (view_mode: {:?}, demo: {})",
       message, self.view_mode, self.tutorial_demo_mode
     ));
-    let x = self.progress_indicator_x_for(message.chars().count()) as u16;
     let y = self.height as u16 - 2;
     self.draw_pdf_loading_slots_buffered(buffer, x, y)?;
     buffer.queue(MoveTo(x, y))?;
-    write!(buffer, "{message}")?;
+    write!(buffer, "{message:>slot$}")?;
     buffer.queue(crossterm::terminal::Clear(
       crossterm::terminal::ClearType::UntilNewLine,
     ))?;
@@ -100,24 +100,32 @@ impl Editor {
   }
 
   pub(crate) fn progress_indicator_message(&self) -> String {
-    if self.pdf_pending.is_some()
-      || self.pdf_streaming.as_ref().is_some_and(|s| !s.fully_loaded)
-    {
-      return "--%".to_string();
-    }
-
-    let progress = self.read_progress_percent();
+    // The percentage is line-based, so it drifts while pages stream in and
+    // `total_lines` keeps growing. Hold it at `--` until the parser finishes
+    // rather than show a number that walks backwards.
+    let percent = if self.progress_is_loading() {
+      "--".to_string()
+    } else {
+      self.read_progress_percent().to_string()
+    };
 
     // PDFs carry a physical page structure readers navigate by, so show the
-    // absolute page alongside the percentage (e.g. `37/250 (18%)`). Flowed
-    // formats (EPUB, plain text, …) have no fixed pages and fall back to the
-    // percentage alone.
+    // absolute page alongside the percentage (e.g. `37/250 (18%)`). The page
+    // counter is shown as soon as the page count is known — including while
+    // the document is still streaming — so it never pops in late and shifts
+    // the rest of the indicator. Flowed formats (EPUB, plain text, …) have no
+    // fixed pages and fall back to the percentage alone.
     match self.current_page_indicator() {
-      Some((page, total_pages)) => {
-        format!("{page}/{total_pages} ({progress}%)")
-      }
-      None => format!("{progress}%"),
+      Some((page, total_pages)) => format!("{page}/{total_pages} ({percent}%)"),
+      None => format!("{percent}%"),
     }
+  }
+
+  /// True while page content is still being parsed/streamed, so position- and
+  /// percentage-derived values can't be trusted yet.
+  fn progress_is_loading(&self) -> bool {
+    self.pdf_pending.is_some()
+      || self.pdf_streaming.as_ref().is_some_and(|s| !s.fully_loaded)
   }
 
   /// Reading progress as a whole-number percentage of lines consumed, clamped
@@ -134,26 +142,49 @@ impl Editor {
   }
 
   /// `(current_page_1based, total_pages)` for a streaming PDF whose page table
-  /// is known, or `None` for formats without physical pages.
+  /// is known, or `None` when the page counter is off or the format has no
+  /// physical pages.
   fn current_page_indicator(&self) -> Option<(u32, usize)> {
-    let total_pages = self.pdf_streaming.as_ref()?.pages.len();
-    if total_pages == 0 {
-      return None;
-    }
+    let total_pages = self.page_counter_total()?;
     let (page, _) = self.current_pdf_position()?;
     Some((page, total_pages))
   }
 
-  pub(crate) fn progress_indicator_x(&self) -> usize {
-    self.progress_indicator_x_for(
-      self.progress_indicator_message().chars().count(),
-    )
+  /// Total page count to surface, or `None` when the page counter is disabled
+  /// (the default) or the document has no physical pages. Page numbers are
+  /// only available for PDFs, whose page table gives an authoritative count;
+  /// flowed formats (EPUB, DOCX, plain text, …) have no fixed pages.
+  fn page_counter_total(&self) -> Option<usize> {
+    if !self.show_page_numbers {
+      return None;
+    }
+    let total_pages = self.pdf_streaming.as_ref()?.pages.len();
+    (total_pages > 0).then_some(total_pages)
   }
 
-  /// Right-anchor a message of `message_len` columns, leaving
-  /// `PROGRESS_RIGHT_MARGIN` blank columns at the terminal edge.
-  pub(crate) fn progress_indicator_x_for(&self, message_len: usize) -> usize {
-    self.width.saturating_sub(message_len).saturating_sub(PROGRESS_RIGHT_MARGIN)
+  /// Columns reserved for the progress indicator. When the page counter is
+  /// shown this is held at the widest it can reach for the current document
+  /// (`{total}/{total} (100%)`) so its left edge — and therefore the loading
+  /// spinners drawn beside it — stay put as the page, percentage, and loading
+  /// placeholder fill in. Otherwise it is just the percentage (`100%`).
+  pub(crate) fn progress_indicator_slot_width(&self) -> usize {
+    match self.page_counter_total() {
+      Some(total) => format!("{total}/{total} (100%)").len(),
+      None => "100%".len(),
+    }
+  }
+
+  /// Reserved slot width and the column to start drawing at, right-anchored
+  /// `PROGRESS_RIGHT_MARGIN` columns from the terminal edge.
+  pub(crate) fn progress_indicator_layout(&self) -> (usize, u16) {
+    let slot = self.progress_indicator_slot_width();
+    let x =
+      self.width.saturating_sub(slot).saturating_sub(PROGRESS_RIGHT_MARGIN);
+    (slot, x as u16)
+  }
+
+  pub(crate) fn progress_indicator_x(&self) -> usize {
+    self.progress_indicator_layout().1 as usize
   }
 
   fn pdf_loading_slots_message(&self) -> String {

--- a/cli-text-reader/src/editor/status_line/tests.rs
+++ b/cli-text-reader/src/editor/status_line/tests.rs
@@ -138,17 +138,33 @@ fn progress_indicator_position_is_stable_across_load_completion() {
   editor.show_page_numbers = true;
 
   // The reserved slot depends only on the (fixed) total page count, so the
-  // indicator's start column — and the loading spinners drawn beside it —
+  // indicator's start column — and the loading spinners packed beside it —
   // must not move when streaming finishes and the percentage fills in.
-  let loaded = editor.progress_indicator_layout();
+  let loaded = editor.progress_indicator_slot_width();
   editor.pdf_streaming.as_mut().expect("streaming state").fully_loaded = false;
-  let loading = editor.progress_indicator_layout();
+  let loading = editor.progress_indicator_slot_width();
 
   assert_eq!(loaded, loading);
   // And the rendered text never exceeds the reserved slot, so it can be
   // right-aligned without shifting.
-  let (slot, _) = loaded;
-  assert!(editor.progress_indicator_message().chars().count() <= slot);
+  assert!(editor.progress_indicator_message().chars().count() <= loaded);
+}
+
+#[test]
+fn page_slot_widens_only_when_page_numbers_enabled() {
+  let Some(mut editor) = editor_with_streaming_parser_state(true) else {
+    return;
+  };
+
+  // Disabled (the default): the bar reserves just the percentage slot, so it
+  // does not account for page numbers.
+  assert!(!editor.show_page_numbers);
+  let percentage_only = editor.progress_indicator_slot_width();
+  assert_eq!(percentage_only, "100%".len());
+
+  // Enabled: the reservation grows to fit the widest page counter.
+  editor.show_page_numbers = true;
+  assert!(editor.progress_indicator_slot_width() > percentage_only);
 }
 
 #[test]
@@ -182,4 +198,73 @@ fn command_completion_text_hides_when_command_uses_line() {
   editor.editor_state.command_completion = Some("about author".to_string());
 
   assert!(editor.command_completion_text(3).is_none());
+}
+
+// --- Status-bar layout primitives -----------------------------------------
+
+use super::layout::{StatusSlot, draw_right_anchored, pack_right_anchored};
+
+/// Minimal `StatusSlot` for exercising the layout engine independently of the
+/// editor's concrete elements.
+struct FixedSlot {
+  width: usize,
+  text: Option<&'static str>,
+}
+
+impl StatusSlot for FixedSlot {
+  fn reserved_width(&self) -> usize {
+    self.width
+  }
+  fn render(&self) -> Option<String> {
+    self.text.map(str::to_string)
+  }
+}
+
+#[test]
+fn pack_right_anchored_packs_slots_leftward_with_gap() {
+  // width 40, margin 2, gap 1, slots [5, 4] given rightmost-first.
+  let starts = pack_right_anchored(40, 2, 1, &[5, 4]);
+  // Rightmost: 40 - 2 - 5 = 33. Next: 33 - 1 - 4 = 28.
+  assert_eq!(starts, vec![33, 28]);
+}
+
+#[test]
+fn pack_right_anchored_saturates_on_narrow_terminal() {
+  assert_eq!(pack_right_anchored(4, 2, 1, &[5, 4]), vec![0, 0]);
+}
+
+#[test]
+fn draw_right_anchored_right_aligns_within_reserved_width() {
+  let progress = FixedSlot { width: 5, text: Some("9%") };
+  let spinner = FixedSlot { width: 4, text: Some("P[.]") };
+  let slots: [&dyn StatusSlot; 2] = [&progress, &spinner];
+
+  let mut buf = Vec::new();
+  draw_right_anchored(&mut buf, 40, 0, 2, 1, &slots).unwrap();
+  let out = String::from_utf8(buf).unwrap();
+
+  // "9%" right-aligned in 5 columns, plus the spinner verbatim.
+  assert!(out.contains("   9%"), "got: {out:?}");
+  assert!(out.contains("P[.]"), "got: {out:?}");
+}
+
+#[test]
+fn unrendered_slot_still_reserves_its_neighbours_column() {
+  fn spinner_output(progress_text: Option<&'static str>) -> String {
+    let progress = FixedSlot { width: 5, text: progress_text };
+    let spinner = FixedSlot { width: 4, text: Some("P[.]") };
+    let slots: [&dyn StatusSlot; 2] = [&progress, &spinner];
+    let mut buf = Vec::new();
+    draw_right_anchored(&mut buf, 40, 0, 2, 1, &slots).unwrap();
+    String::from_utf8(buf).unwrap()
+  }
+
+  // The spinner lands at the same column (MoveTo to col 28 => CSI `1;29H`)
+  // whether or not the rightmost slot draws — reservation, not contents,
+  // fixes the layout.
+  let shown = spinner_output(Some("9%"));
+  let hidden = spinner_output(None);
+  assert!(shown.contains("\u{1b}[1;29H"), "got: {shown:?}");
+  assert!(hidden.contains("\u{1b}[1;29H"), "got: {hidden:?}");
+  assert!(hidden.contains("P[.]"));
 }

--- a/cli-text-reader/src/editor/status_line/tests.rs
+++ b/cli-text-reader/src/editor/status_line/tests.rs
@@ -87,16 +87,30 @@ fn progress_indicator_hides_percentage_until_pdf_parser_finishes() {
     return;
   };
 
-  assert_eq!(editor.progress_indicator_message(), " --%");
+  assert_eq!(editor.progress_indicator_message(), "--%");
 }
 
 #[test]
-fn progress_indicator_shows_percentage_after_pdf_parser_finishes() {
+fn progress_indicator_shows_page_and_percentage_for_pdf() {
   let Some(editor) = editor_with_streaming_parser_state(true) else {
     return;
   };
 
-  assert_eq!(editor.progress_indicator_message(), " 50%");
+  // The fully-loaded fixture has a single page, so the page counter reads
+  // `1/1` while the percentage still reflects the line-based reading position.
+  assert_eq!(editor.progress_indicator_message(), "1/1 (50%)");
+}
+
+#[test]
+fn progress_indicator_shows_percentage_only_without_pages() {
+  // No PDF streaming state means no physical page structure (EPUB, plain
+  // text, …), so only the percentage is shown.
+  let mut editor = Editor::new(vec!["line".to_string(); 100], 80);
+  editor.offset = 49;
+  editor.cursor_y = 0;
+  editor.total_lines = 100;
+
+  assert_eq!(editor.progress_indicator_message(), "50%");
 }
 
 #[test]

--- a/cli-text-reader/src/editor/status_line/tests.rs
+++ b/cli-text-reader/src/editor/status_line/tests.rs
@@ -82,19 +82,23 @@ fn pdf_loading_slots_show_tts_spinner() {
 }
 
 #[test]
-fn progress_indicator_hides_percentage_until_pdf_parser_finishes() {
-  let Some(editor) = editor_with_streaming_parser_state(false) else {
+fn progress_indicator_shows_page_with_pending_percentage_while_loading() {
+  let Some(mut editor) = editor_with_streaming_parser_state(false) else {
     return;
   };
+  editor.show_page_numbers = true;
 
-  assert_eq!(editor.progress_indicator_message(), "--%");
+  // While pages are still streaming the page counter is already known, so it
+  // is shown up front; only the line-based percentage is held at `--`.
+  assert_eq!(editor.progress_indicator_message(), "2/2 (--%)");
 }
 
 #[test]
 fn progress_indicator_shows_page_and_percentage_for_pdf() {
-  let Some(editor) = editor_with_streaming_parser_state(true) else {
+  let Some(mut editor) = editor_with_streaming_parser_state(true) else {
     return;
   };
+  editor.show_page_numbers = true;
 
   // The fully-loaded fixture has a single page, so the page counter reads
   // `1/1` while the percentage still reflects the line-based reading position.
@@ -102,15 +106,49 @@ fn progress_indicator_shows_page_and_percentage_for_pdf() {
 }
 
 #[test]
+fn progress_indicator_hides_pages_when_disabled() {
+  // Page numbers default to off, so even a fully-loaded PDF shows only the
+  // percentage until the reader enables them with `:pagenumbers`.
+  let Some(editor) = editor_with_streaming_parser_state(true) else {
+    return;
+  };
+  assert!(!editor.show_page_numbers);
+
+  assert_eq!(editor.progress_indicator_message(), "50%");
+}
+
+#[test]
 fn progress_indicator_shows_percentage_only_without_pages() {
   // No PDF streaming state means no physical page structure (EPUB, plain
-  // text, …), so only the percentage is shown.
+  // text, …), so only the percentage is shown even with the toggle on.
   let mut editor = Editor::new(vec!["line".to_string(); 100], 80);
+  editor.show_page_numbers = true;
   editor.offset = 49;
   editor.cursor_y = 0;
   editor.total_lines = 100;
 
   assert_eq!(editor.progress_indicator_message(), "50%");
+}
+
+#[test]
+fn progress_indicator_position_is_stable_across_load_completion() {
+  let Some(mut editor) = editor_with_streaming_parser_state(true) else {
+    return;
+  };
+  editor.show_page_numbers = true;
+
+  // The reserved slot depends only on the (fixed) total page count, so the
+  // indicator's start column — and the loading spinners drawn beside it —
+  // must not move when streaming finishes and the percentage fills in.
+  let loaded = editor.progress_indicator_layout();
+  editor.pdf_streaming.as_mut().expect("streaming state").fully_loaded = false;
+  let loading = editor.progress_indicator_layout();
+
+  assert_eq!(loaded, loading);
+  // And the rendered text never exceeds the reserved slot, so it can be
+  // right-aligned without shifting.
+  let (slot, _) = loaded;
+  assert!(editor.progress_indicator_message().chars().count() <= slot);
 }
 
 #[test]

--- a/cli-text-reader/src/editor/status_line/tests.rs
+++ b/cli-text-reader/src/editor/status_line/tests.rs
@@ -2,7 +2,9 @@ use super::super::core::Editor;
 use super::progress::{
   PDF_LOADING_SLOT_WIDTH, pdf_loading_slots_message_for_state,
 };
-use crate::editor::streaming::{LoadedPage, PageSlot, PdfStreamingState};
+use crate::editor::streaming::{
+  LoadedPage, PageSlot, PdfStreamingState, PendingPdfStream,
+};
 use cli_pdf_to_text::PdfStream;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, mpsc};
@@ -162,9 +164,36 @@ fn page_slot_widens_only_when_page_numbers_enabled() {
   let percentage_only = editor.progress_indicator_slot_width();
   assert_eq!(percentage_only, "100%".len());
 
-  // Enabled: the reservation grows to fit the widest page counter.
+  // Enabled: the reservation grows to fit a (digit-floored) page counter.
   editor.show_page_numbers = true;
   assert!(editor.progress_indicator_slot_width() > percentage_only);
+}
+
+#[test]
+fn page_slot_reserved_consistently_from_open_through_load() {
+  // Page numbers on, PDF still opening: `pdf_pending` is set but no page table
+  // exists yet. The slot must already reserve page-counter width so nothing
+  // shifts the instant streaming begins.
+  let mut opening = Editor::new(vec!["opening".to_string()], 80);
+  opening.show_page_numbers = true;
+  let (_tx, rx) = mpsc::channel();
+  opening.pdf_pending = Some(PendingPdfStream {
+    receiver: rx,
+    started_at: std::time::Instant::now(),
+    canonical_path_display: "doc.pdf".to_string(),
+    restore_line_in_page: None,
+    restore_cursor_y: None,
+  });
+  let opening_slot = opening.progress_indicator_slot_width();
+  assert!(opening_slot > "100%".len());
+
+  // A typical PDF (page count under the digit floor) reserves exactly the same
+  // width once streaming, so the indicator does not jump from the open splash.
+  let Some(mut streaming) = editor_with_streaming_parser_state(false) else {
+    return;
+  };
+  streaming.show_page_numbers = true;
+  assert_eq!(streaming.progress_indicator_slot_width(), opening_slot);
 }
 
 #[test]

--- a/cli-text-reader/src/editor/tutorial_interactive/navigation.rs
+++ b/cli-text-reader/src/editor/tutorial_interactive/navigation.rs
@@ -124,6 +124,7 @@ impl Editor {
       enable_line_highlighter: None,
       show_cursor: None,
       show_progress: None,
+      show_page_numbers: None,
       pdf_ocr: None,
       tutorial_shown: Some(true),
     };


### PR DESCRIPTION
Closes #95

## What

Adds an optional **page counter** to the status bar for PDFs, shown next to the reading percentage:

```
37/501 (18%)
```

This gives absolute position, total scope, and relative progress at a glance — the "what page am I on?" question the issue raises — without cluttering the default UI.

It is **disabled by default**: out of the box the status bar still shows just the percentage. Readers opt in (see below).

## Trying it out

Install this branch directly:

```sh
cargo install --locked --git https://github.com/kruseio/hygg --branch feat/status-bar-page-number hygg
```

Then open a PDF and turn the counter on with `:pagenumbers` (or `:pn`), or launch with it pre-enabled:

```sh
SHOW_PAGE_NUMBERS=true hygg doc.pdf
```

## Enabling page numbers

Any of these work; the command and config persist the choice for future launches:

- **In-app command:** `:pagenumbers` (or `:pn`) toggles it for the current session and saves it.
- **Config file** (`~/.config/hygg/.env`): set `SHOW_PAGE_NUMBERS=true`.
- **Environment variable:** `SHOW_PAGE_NUMBERS=true hygg doc.pdf`.

Default is `SHOW_PAGE_NUMBERS=false`.

## How it works

- The page number reuses the existing PDF streaming page table: current page from `current_pdf_position()` (already used for progress persistence/OCR), total from the page table length — an authoritative count straight from the document.
- The percentage stays **line-based** reading progress, so it can legitimately differ from the page ratio (matching the `37/501 (18%)` shape in the issue).
- The status bar's right-anchored elements go through a small `StatusSlot` layout engine where **declaring a reserved width is mandatory** (enforced by the trait), and slots are packed by those reservations. The reservation is dynamic by toggle: disabled, the bar reserves only the percentage slot; enabled (for a PDF), it reserves a page-counter slot.
- That reservation is **stable from the very first frame**. The real page count isn't known while the PDF is still opening, so rather than reserve the exact `{total}/{total} (100%)` (which would jump the moment streaming starts), it reserves a digit-floored width that the real count only ever *fills into*. The counter itself also appears as soon as the count is known (while still streaming, percentage held at `--`). Net effect: the indicator — and the loading spinners packed beside it — never shift across open → stream → loaded, or when the toggle changes.

## Limitations

**Page numbers are only available for PDFs right now.** For any other format the status bar falls back to the percentage alone, regardless of the toggle.

This is a property of the formats, not an oversight:

- A **PDF** *is* a sequence of physical pages — hygg's extractor walks the page tree, so the page count and current page are authoritative.
- **EPUB, DOCX, and other flowed formats** have no fixed pages stored in the file. Pagination is computed at render time by the reading app from font, margins, page size, etc., and hygg ingests these via pandoc (`--to=plain`), which flattens them to reflowed text with no page boundaries. There is simply no authoritative page data to show. Inventing one (e.g. lines-per-"page") would be a synthetic estimate, not a real page number, so it is intentionally left out for now.

## Tests

- PDF with toggle on: shows `1/1 (50%)` (fully loaded) and `2/2 (--%)` (still streaming).
- Toggle off (default): PDF shows `50%` only; the reserved slot stays percentage-sized.
- Non-PDF: shows `50%` only, even with the toggle on.
- Reserved slot is identical across the open splash, streaming, and full load (regression tests for the first-load jump), and widens only when the toggle is enabled.
- `StatusSlot` layout primitives: right-to-left packing with gaps, narrow-terminal saturation, right-alignment within reserved width, and stable neighbour columns when a slot renders nothing.
- `:pagenumbers` / `:pn` classify to the toggle command.
- Full `cli-text-reader` lib suite (incl. TTS-gated) passes; `clippy --all-targets --all-features` clean; nightly `rustfmt` clean; changed files under the 300-LOC gate.