### PR TITLE
docs: point the star history chart at its new home

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ Visit the [Documentation](https://github.com/kruseio/hygg/blob/main/docs/README.
 
 ## Star History
 
-<a href="https://www.star-history.com/#kruseio/hygg&Date">
+<a href="https://star-history.dera.page/#kruseio/hygg&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=kruseio/hygg&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=kruseio/hygg&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=kruseio/hygg&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=kruseio/hygg&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=kruseio/hygg&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=kruseio/hygg&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart is currently broken and this change is needed to bring it back online.

Update the chart markup and the surrounding link in the README so the chart renders again.